### PR TITLE
Make vue-fuse compatible with Server Side Rendering

### DIFF
--- a/src/VueFuse.vue
+++ b/src/VueFuse.vue
@@ -3,7 +3,9 @@
 </template>
 <script>
 import Fuse from 'fuse.js'
-window.Fuse = Fuse
+if (typeof window !== 'undefined') {
+  window.Fuse = Fuse
+}
 
 export default {
   data () {


### PR DESCRIPTION
This modification makes it possible to use fuse with SSR frameworks like Nuxt, ream and others by preventing the injection of Fuse into the window object when there is none.