### PR TITLE
Search prop reactive

### DIFF
--- a/src/VueFuse.vue
+++ b/src/VueFuse.vue
@@ -14,6 +14,10 @@ export default {
     }
   },
   props: {
+    search: {
+      type: String,
+      default: ''
+    },
     eventName: {
       type: String,
       default: 'fuseResultsUpdated'


### PR DESCRIPTION
Search prop is now reactive to the value passed in component. For example, getting the value from the URL (using https://github.com/vuejs/vuex-router-sync): 

```vue
<vue-fuse :search="$store.state.route.query.search"/>
```

Fixes #20 #22

Can't believe it's so simple, but I tested a lot of cases and it works like a charm. <3 Vue.