### PR TITLE
fix(package): vue should be a peer dep, details follow

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,10 +28,13 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
-    "vue": "^2.5.17",
     "fuse.js": "^3.2.0"
   },
+  "peerDependencies": {
+    "vue": "^2.5.17"
+  },
   "devDependencies": {
+    "vue": "^2.5.17",
     "@vue/cli-plugin-babel": "^3.0.1",
     "@vue/cli-plugin-eslint": "^3.0.1",
     "@vue/cli-service": "^3.0.1",


### PR DESCRIPTION
As a plugin, this should not hard depend on Vue, but rather specify a
compatible range in `peerDependencies`, most libraries/plugins
(including those in the Vue ecosystem) seem to be using this pattern.
A hard depend (as of now), means that it will result in multiple Vue
installs and even loads at runtime.