### PR TITLE
Fix factory function error

### DIFF
--- a/src/components/VueFuse.vue
+++ b/src/components/VueFuse.vue
@@ -54,7 +54,9 @@ export default {
     },
     tokenSeparator: {
       type: RegExp,
-      default: RegExp(' ')
+      default() {
+        return new RegExp(' ');
+      }
     },
     matchAllTokens: {
       type: Boolean,


### PR DESCRIPTION
Noticed an error with new version, commit fixes the following error:

```
Invalid default value for prop "tokenSeparator": Props with type Object/Array must use a factory function to return the default value.
```